### PR TITLE
ci: Bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.x"
 
@@ -26,7 +26,7 @@ jobs:
           npm run build
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             dist/main.js


### PR DESCRIPTION
## Summary
Silences the `Node.js 20 actions are deprecated` annotation. GitHub forces these actions to Node 24 on **2026-06-02** and removes Node 20 from runners on 2026-09-16.

Bumped to the current major versions, all of which run on Node 24:

| Action | Was | Now | Files |
|--------|-----|-----|-------|
| `actions/checkout` | `@v4` | `@v6` | ci.yml, release.yml |
| `actions/setup-node` | `@v4` | `@v6` | ci.yml, release.yml |
| `actions/attest-build-provenance` | `@v2` | `@v4` | release.yml |

## Test Plan
- [ ] CI passes on this PR with no Node 20 deprecation annotation
- [ ] Next tagged release still produces a verifiable provenance attestation

🤖 Generated with [Claude Code](https://claude.com/claude-code)