### PR TITLE
fix: Support 2-digit year (YY) in date formats

### DIFF
--- a/__tests__/core/date-parser.test.ts
+++ b/__tests__/core/date-parser.test.ts
@@ -72,3 +72,24 @@ describe('parseDate', () => {
 		expect(parseDate('02-04-2026', 'YYYY-MM-DD')).toBeNull();
 	});
 });
+
+describe('two-digit year (YY) format', () => {
+	it('formats a date with YY.MM.DD format', () => {
+		const date = new Date(2026, 4, 20); // May 20, 2026
+		expect(formatDate(date, 'YY.MM.DD')).toBe('26.05.20');
+	});
+
+	it('parses a YY.MM.DD date into the current century', () => {
+		// Round-trip today's date: a 2-digit year must resolve to the
+		// current century, not the 1900s (the date-fns reference-date trap).
+		const today = new Date();
+		const result = parseDate(formatDate(today, 'YY.MM.DD'), 'YY.MM.DD');
+		expect(result?.getFullYear()).toBe(today.getFullYear());
+		expect(result?.getMonth()).toBe(today.getMonth());
+		expect(result?.getDate()).toBe(today.getDate());
+	});
+
+	it('returns null for an invalid YY.MM.DD date', () => {
+		expect(parseDate('26.13.20', 'YY.MM.DD')).toBeNull(); // Invalid month
+	});
+});

--- a/src/core/date-parser.ts
+++ b/src/core/date-parser.ts
@@ -8,16 +8,23 @@ export const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD';
 
 /**
  * Convert moment-style format tokens to date-fns tokens.
- * YYYY → yyyy, DD → dd (MM is the same in both).
+ * YYYY → yyyy, YY → yy, DD → dd (MM is the same in both).
+ *
+ * YYYY is replaced before YY so the four-digit token is not mistaken
+ * for two two-digit ones. date-fns treats bare YY/YYYY as week-numbering
+ * year tokens and throws, so every year token must be lower-cased.
  */
 function toFnsFormat(format: string): string {
-	return format.replace('YYYY', 'yyyy').replace('DD', 'dd');
+	return format
+		.replace(/YYYY/g, 'yyyy')
+		.replace(/YY/g, 'yy')
+		.replace(/DD/g, 'dd');
 }
 
 /**
  * Format a Date object as a string using the given format.
  *
- * Supported tokens: YYYY (year), MM (month), DD (day)
+ * Supported tokens: YYYY (4-digit year), YY (2-digit year), MM (month), DD (day)
  */
 export function formatDate(date: Date, format: string = DEFAULT_DATE_FORMAT): string {
 	return fnsFormat(date, toFnsFormat(format));
@@ -32,7 +39,9 @@ export function parseDate(dateString: string, format: string = DEFAULT_DATE_FORM
 	if (!dateString) return null;
 
 	const fmtStr = toFnsFormat(format);
-	const date = fnsParse(dateString, fmtStr, new Date(0));
+	// Use the current date as the reference so a 2-digit year (YY)
+	// resolves into the present century rather than the 1900s.
+	const date = fnsParse(dateString, fmtStr, new Date());
 
 	if (!isValid(date)) return null;
 


### PR DESCRIPTION
Fixes #19

## Problem
With a date format containing `YY` (e.g. `YY.MM.DD`, which Moments auto-detects from the Daily Notes plugin), the timeline shows "No moments yet" and **"Create your first moment" does nothing**.

## Root cause
`toFnsFormat()` in `src/core/date-parser.ts` translated only `YYYY`→`yyyy` and `DD`→`dd`, leaving a bare `YY`. date-fns interprets `YY` as a *week-numbering-year* Unicode token and throws a `RangeError` for both `format()` and `parse()`.

The `MomentModal` constructor calls `formatDate(new Date(), settings.dateFormat)` — so opening the modal threw before it could render. The button silently failed.

A secondary bug: `parseDate()` used `new Date(0)` (1970) as date-fns' reference date. date-fns resolves 2-digit years relative to the reference's century, so `26` parsed as **1926** — a moment created with a `YY` format would be indexed in 1926 and never appear on the timeline.

## Fix
- `toFnsFormat()` now translates `YY`→`yy` (after `YYYY`, so the 4-digit token still wins) using global replacement.
- `parseDate()` parses against the current date, so 2-digit years resolve into the present century.

## Tests
Added 3 tests to `date-parser.test.ts` (format, century-correct parse round-trip, invalid-date rejection). Verified RED first — all three threw the exact `RangeError: Use \`yy\` instead of \`YY\`` — then GREEN after the fix. Full suite: 241/241 pass, lint and build clean.

## Known related limitation (out of scope)
`src/core/periodic-detection.ts` also tokenizes date formats and still handles only `YYYY`. Periodic-note *detection* for `YY`-based daily-note formats remains unfixed — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)