### PR TITLE
Fix template evaluation, modal button order, and timeline UI (#16, #17, #18)

### DIFF
--- a/__tests__/core/template-engine.test.ts
+++ b/__tests__/core/template-engine.test.ts
@@ -2,6 +2,7 @@ import {
 	renderTemplate,
 	buildHeadingString,
 	buildFilename,
+	evaluateCoreTemplate,
 	type TemplateVariables,
 } from '../../src/core/template-engine';
 
@@ -149,5 +150,48 @@ describe('buildFilename', () => {
 		const vars: TemplateVariables = { date: '2026-02-04', title: null };
 		const result = buildFilename(vars);
 		expect(result).toBe('2026-02-04.md');
+	});
+});
+
+describe('evaluateCoreTemplate', () => {
+	const now = new Date('2026-02-04T14:30:00');
+	const opts = {
+		title: 'My Note',
+		dateFormat: 'YYYY-MM-DD',
+		timeFormat: 'HH:mm',
+		now,
+	};
+
+	it('replaces {{title}} with the note title', () => {
+		expect(evaluateCoreTemplate('# {{title}}', opts)).toBe('# My Note');
+	});
+
+	it('replaces {{date}} using the default date format', () => {
+		expect(evaluateCoreTemplate('{{date}}', opts)).toBe('2026-02-04');
+	});
+
+	it('replaces {{time}} using the default time format', () => {
+		expect(evaluateCoreTemplate('{{time}}', opts)).toBe('14:30');
+	});
+
+	it('replaces {{date:FORMAT}} with the inline format', () => {
+		expect(evaluateCoreTemplate('{{date:YYYY}}', opts)).toBe('2026');
+	});
+
+	it('replaces {{time:FORMAT}} with the inline format', () => {
+		expect(evaluateCoreTemplate('{{time:HH}}', opts)).toBe('14');
+	});
+
+	it('replaces multiple placeholders in one template', () => {
+		const result = evaluateCoreTemplate('{{title}} — {{date}} {{time}}', opts);
+		expect(result).toBe('My Note — 2026-02-04 14:30');
+	});
+
+	it('leaves unknown placeholders untouched', () => {
+		expect(evaluateCoreTemplate('{{foo}}', opts)).toBe('{{foo}}');
+	});
+
+	it('repeats the same placeholder', () => {
+		expect(evaluateCoreTemplate('{{title}} {{title}}', opts)).toBe('My Note My Note');
 	});
 });

--- a/__tests__/core/timeline-helpers.test.ts
+++ b/__tests__/core/timeline-helpers.test.ts
@@ -4,6 +4,8 @@ import {
 	groupMomentsByDate,
 	formatImplicitSummary,
 	formatActiveFileIndicator,
+	findMonthWithDates,
+	hasDatesBefore,
 } from '../../src/core/timeline-helpers';
 import type { Moment } from '../../src/types';
 
@@ -149,5 +151,69 @@ describe('formatActiveFileIndicator', () => {
 	it('formats plural moment count', () => {
 		expect(formatActiveFileIndicator(3, 'Project Alpha'))
 			.toBe('3 moments in Project Alpha');
+	});
+});
+
+describe('findMonthWithDates', () => {
+	it('finds dates in the start month', () => {
+		const result = findMonthWithDates('2026-05', ['2026-05-04', '2026-05-20'], []);
+		expect(result.monthWithDates).toBe('2026-05');
+		expect(result.dates).toEqual(['2026-05-20', '2026-05-04']);
+		expect(result.visitedMonths).toEqual(['2026-05']);
+	});
+
+	it('sorts the returned dates newest-first', () => {
+		const result = findMonthWithDates('2026-05', ['2026-05-04', '2026-05-28', '2026-05-15'], []);
+		expect(result.dates).toEqual(['2026-05-28', '2026-05-15', '2026-05-04']);
+	});
+
+	it('walks backward past empty months until it finds dates', () => {
+		const result = findMonthWithDates('2026-05', ['2026-03-10'], []);
+		expect(result.monthWithDates).toBe('2026-03');
+		expect(result.dates).toEqual(['2026-03-10']);
+		expect(result.visitedMonths).toEqual(['2026-05', '2026-04', '2026-03']);
+	});
+
+	it('combines explicit and implicit dates', () => {
+		const result = findMonthWithDates('2026-05', ['2026-05-04'], ['2026-05-09']);
+		expect(result.dates).toEqual(['2026-05-09', '2026-05-04']);
+	});
+
+	it('crosses the year boundary when walking backward', () => {
+		const result = findMonthWithDates('2026-01', ['2025-12-31'], []);
+		expect(result.monthWithDates).toBe('2025-12');
+		expect(result.visitedMonths).toEqual(['2026-01', '2025-12']);
+	});
+
+	it('returns no month when nothing is found within maxDepth', () => {
+		const result = findMonthWithDates('2026-05', ['2020-01-01'], []);
+		expect(result.monthWithDates).toBeNull();
+		expect(result.dates).toEqual([]);
+		// start month plus 12 previous months are all inspected
+		expect(result.visitedMonths).toHaveLength(13);
+	});
+
+	it('respects a custom maxDepth', () => {
+		const result = findMonthWithDates('2026-05', ['2026-01-01'], [], 2);
+		expect(result.monthWithDates).toBeNull();
+		expect(result.visitedMonths).toEqual(['2026-05', '2026-04', '2026-03']);
+	});
+});
+
+describe('hasDatesBefore', () => {
+	it('returns true when a date precedes the month', () => {
+		expect(hasDatesBefore(['2026-04-30', '2026-06-01'], '2026-05')).toBe(true);
+	});
+
+	it('returns false when all dates are in or after the month', () => {
+		expect(hasDatesBefore(['2026-05-01', '2026-07-15'], '2026-05')).toBe(false);
+	});
+
+	it('treats a date within the same month as not before it', () => {
+		expect(hasDatesBefore(['2026-05-15'], '2026-05')).toBe(false);
+	});
+
+	it('returns false for an empty date set', () => {
+		expect(hasDatesBefore([], '2026-05')).toBe(false);
 	});
 });

--- a/src/core/template-engine.ts
+++ b/src/core/template-engine.ts
@@ -1,3 +1,5 @@
+import { moment } from 'obsidian';
+
 /**
  * Variables available for template substitution
  */
@@ -48,6 +50,40 @@ export function renderTemplate(
 		}
 		return value;
 	});
+}
+
+/**
+ * Evaluate the placeholders supported by Obsidian's core Templates plugin:
+ * `{{title}}`, `{{date}}`, `{{time}}`, and the formatted variants
+ * `{{date:FORMAT}}` and `{{time:FORMAT}}`.
+ *
+ * Used when applying a template without Templater available, so core-style
+ * placeholders are resolved rather than inserted verbatim.
+ *
+ * @param template - Raw template content
+ * @param options - Title, default date/time formats, and optional fixed time
+ * @returns Content with core placeholders replaced
+ */
+export function evaluateCoreTemplate(
+	template: string,
+	options: {
+		title: string;
+		dateFormat: string;
+		timeFormat: string;
+		now?: Date;
+	}
+): string {
+	const now = moment(options.now ?? new Date());
+	return template.replace(
+		/\{\{(title|date|time)(?::([^}]*))?\}\}/g,
+		(_match, name: string, format: string | undefined) => {
+			if (name === 'title') {
+				return options.title;
+			}
+			const defaultFormat = name === 'date' ? options.dateFormat : options.timeFormat;
+			return now.format(format?.trim() || defaultFormat);
+		}
+	);
 }
 
 /**

--- a/src/core/timeline-helpers.ts
+++ b/src/core/timeline-helpers.ts
@@ -31,6 +31,71 @@ export function getDatesForMonth(
 }
 
 /**
+ * Result of searching backward for a month containing dates.
+ */
+export interface MonthSearchResult {
+	/** Every month inspected during the search (start month first, oldest last). */
+	visitedMonths: string[];
+	/** The first month, searching backward, that contains dates — or null. */
+	monthWithDates: string | null;
+	/** Dates in `monthWithDates`, sorted newest-first. Empty when none found. */
+	dates: string[];
+}
+
+/**
+ * Search backward from `startMonth` for the first month containing dates.
+ *
+ * Inspects the start month and up to `maxDepth` previous months. Every month
+ * inspected is returned in `visitedMonths` so the caller can mark them all as
+ * loaded, avoiding repeat scans of empty months.
+ *
+ * @param startMonth - Month to start from (YYYY-MM)
+ * @param explicitDates - Dates of explicit moments (YYYY-MM-DD)
+ * @param implicitDates - Dates of implicit moments (YYYY-MM-DD)
+ * @param maxDepth - How many previous months to inspect beyond the start month
+ */
+export function findMonthWithDates(
+	startMonth: string,
+	explicitDates: Iterable<string>,
+	implicitDates: Iterable<string>,
+	maxDepth: number = 12
+): MonthSearchResult {
+	const explicit = new Set(explicitDates);
+	const implicit = new Set(implicitDates);
+	const visitedMonths: string[] = [];
+	let month = startMonth;
+
+	for (let depth = 0; depth <= maxDepth; depth++) {
+		visitedMonths.push(month);
+		const dates = getDatesForMonth(month, explicit, implicit);
+		if (dates.length > 0) {
+			dates.sort((a, b) => b.localeCompare(a));
+			return { visitedMonths, monthWithDates: month, dates };
+		}
+		month = getPreviousMonth(month);
+	}
+
+	return { visitedMonths, monthWithDates: null, dates: [] };
+}
+
+/**
+ * Whether any date falls strictly before the given month.
+ *
+ * Date strings are YYYY-MM-DD and the month is YYYY-MM; lexical comparison
+ * against the shorter month prefix correctly treats every day of an earlier
+ * month as "before" and every day of the same month as not before.
+ *
+ * @param allDates - Date strings to check (YYYY-MM-DD)
+ * @param month - Month boundary (YYYY-MM)
+ */
+export function hasDatesBefore(allDates: Iterable<string>, month: string): boolean {
+	for (const date of allDates) {
+		if (date < month) return true;
+	}
+	return false;
+}
+
+/**
  * Group moments by their date, sorted newest first within each day.
  */
 export function groupMomentsByDate(moments: Moment[]): Map<string, Moment[]> {

--- a/src/ui/moment-modal.ts
+++ b/src/ui/moment-modal.ts
@@ -74,8 +74,13 @@ export class MomentModal extends Modal {
 				});
 			});
 
-		// Buttons
+		// Buttons — Cancel on the left, primary Create action on the right
 		new Setting(contentEl)
+			.addButton((btn) =>
+				btn.setButtonText('Cancel').onClick(() => {
+					this.close();
+				})
+			)
 			.addButton((btn) =>
 				btn
 					.setButtonText('Create')
@@ -83,11 +88,6 @@ export class MomentModal extends Modal {
 					.onClick(() => {
 						this.submit();
 					})
-			)
-			.addButton((btn) =>
-				btn.setButtonText('Cancel').onClick(() => {
-					this.close();
-				})
 			);
 
 		// Handle Enter key — Modal.scope is auto-managed (pushed on open, popped on close)

--- a/src/ui/template-suggester.ts
+++ b/src/ui/template-suggester.ts
@@ -1,5 +1,6 @@
 import { App, FuzzySuggestModal, TFile, TFolder, normalizePath } from 'obsidian';
 import { getCommunityPlugin, getInternalPlugin } from '../utils/obsidian-helpers';
+import { evaluateCoreTemplate } from '../core/template-engine';
 
 /**
  * Get the templates folder path from core Templates plugin or Templater.
@@ -75,9 +76,28 @@ export async function applyTemplate(app: App, file: TFile, templateFile: TFile):
 		}
 	}
 
-	// Fallback: read template content and write to file
+	// Fallback: read the template, evaluate core Templates placeholders
+	// ({{title}}, {{date}}, {{time}}), and write the result to the file.
 	const templateContent = await app.vault.read(templateFile);
-	await app.vault.modify(file, templateContent);
+	const { dateFormat, timeFormat } = getCoreTemplateFormats(app);
+	const evaluated = evaluateCoreTemplate(templateContent, {
+		title: file.basename,
+		dateFormat,
+		timeFormat,
+	});
+	await app.vault.modify(file, evaluated);
+}
+
+/**
+ * Read the date/time formats configured for the core Templates plugin,
+ * falling back to its defaults when unset.
+ */
+function getCoreTemplateFormats(app: App): { dateFormat: string; timeFormat: string } {
+	const options = getInternalPlugin(app, 'templates')?.instance?.options;
+	return {
+		dateFormat: (options?.['dateFormat'] as string) || 'YYYY-MM-DD',
+		timeFormat: (options?.['timeFormat'] as string) || 'HH:mm',
+	};
 }
 
 /**

--- a/src/views/timeline-view.ts
+++ b/src/views/timeline-view.ts
@@ -5,7 +5,7 @@ import { TIMELINE_VIEW_TYPE } from '../constants';
 import { formatDate } from '../core/date-parser';
 import { extractContentUnderHeading } from '../core/content-extractor';
 import { debug, debugTimed } from '../utils/debug';
-import { getPreviousMonth, getDatesForMonth, groupMomentsByDate, formatActiveFileIndicator } from '../core/timeline-helpers';
+import { getPreviousMonth, groupMomentsByDate, formatActiveFileIndicator, findMonthWithDates, hasDatesBefore } from '../core/timeline-helpers';
 
 /**
  * Timeline view displaying moments grouped by day.
@@ -20,7 +20,8 @@ export class TimelineView extends ItemView {
 	private configOpen: boolean = false;
 	private pinned = false;
 	private pinnedBtn: HTMLButtonElement;
-	private scrollHandler: (() => void) | null = null;
+	private loadMoreObserver: IntersectionObserver | null = null;
+	private loadMoreSentinel: HTMLElement | null = null;
 	private filter: TimelineFilter = {
 		startDate: null,
 		endDate: null,
@@ -85,7 +86,7 @@ export class TimelineView extends ItemView {
 	}
 
 	onClose(): Promise<void> {
-		this.removeScrollListener();
+		this.destroyLoadMoreObserver();
 		this.destroyCardObserver();
 		this.contentCache.clear();
 		return Promise.resolve();
@@ -262,6 +263,7 @@ export class TimelineView extends ItemView {
 
 		// Tear down previous render state
 		this.destroyCardObserver();
+		this.destroyLoadMoreObserver();
 		this.timelineContentEl.empty();
 
 		// Reset pagination state
@@ -293,17 +295,17 @@ export class TimelineView extends ItemView {
 		// Set up lazy rendering observer
 		this.setupCardObserver();
 
+		// Set up the observer that auto-loads older months
+		this.setupLoadMoreObserver();
+
 		// Determine which month to start with
 		const startMonth = this.getStartMonth();
 
 		// Load initial month
 		this.loadMonth(startMonth);
 
-		// Add scroll listener for infinite loading
-		this.setupScrollListener();
-
-		// Add "load more" button as fallback
-		this.addLoadMoreButton();
+		// Add the sentinel that triggers loading older months when scrolled near
+		this.addLoadMoreSentinel();
 
 		done();
 	}
@@ -344,37 +346,28 @@ export class TimelineView extends ItemView {
 		return formatDate(new Date()).substring(0, 7);
 	}
 
-	private loadMonth(
-		month: string,
-		searchDepth: number = 0
-	): void {
+	private loadMonth(month: string): void {
 		if (this.loadedMonths.has(month)) {
 			return;
 		}
 
-		this.loadedMonths.add(month);
+		// Search backward (up to 12 months) for a month that has dates.
+		const result = findMonthWithDates(
+			month,
+			this.groupedByDate.keys(),
+			this.allImplicitByDate.keys()
+		);
 
-		// Track oldest loaded month
-		if (!this.oldestLoadedMonth || month < this.oldestLoadedMonth) {
-			this.oldestLoadedMonth = month;
-		}
-
-		// Get all dates for this month
-		const monthDates = getDatesForMonth(month, this.groupedByDate.keys(), this.allImplicitByDate.keys());
-
-		if (monthDates.length === 0) {
-			// No dates in this month, try older months (up to 12 months back on initial load)
-			if (searchDepth < 12) {
-				const prevMonth = getPreviousMonth(month);
-				this.loadMonth(prevMonth, searchDepth + 1);
+		// Mark every inspected month as loaded so empty months aren't re-scanned.
+		for (const visited of result.visitedMonths) {
+			this.loadedMonths.add(visited);
+			if (!this.oldestLoadedMonth || visited < this.oldestLoadedMonth) {
+				this.oldestLoadedMonth = visited;
 			}
-			return;
 		}
 
-		// Render days in this month (sorted newest first)
-		monthDates.sort((a, b) => b.localeCompare(a));
-
-		for (const date of monthDates) {
+		// Render the days of the month that contained dates (newest first).
+		for (const date of result.dates) {
 			const dayMoments = this.groupedByDate.get(date) || [];
 			const dayImplicit = this.allImplicitByDate.get(date) || [];
 
@@ -394,51 +387,44 @@ export class TimelineView extends ItemView {
 
 		// Check if there are any dates older than our oldest loaded month
 		const allDates = new Set([...this.groupedByDate.keys(), ...this.allImplicitByDate.keys(), ...this.activeFileMomentsByDate.keys()]);
-		const hasOlderDates = Array.from(allDates).some((date) => date < this.oldestLoadedMonth!);
+		const hasOlderDates = hasDatesBefore(allDates, this.oldestLoadedMonth);
 
 		if (!hasOlderDates) {
 			this.hasMoreMonths = false;
-			this.removeLoadMoreButton();
+			this.removeLoadMoreSentinel();
 			this.isLoadingMore = false;
 			return;
 		}
 
-		// Load the previous month (which may recursively load more if empty)
-		this.loadMonth(prevMonthStr, 0);
+		// Load the previous month (skips back over empty months to find dates)
+		this.loadMonth(prevMonthStr);
 
 		this.isLoadingMore = false;
 
-		// Update load more button visibility
-		this.updateLoadMoreButton();
+		// Keep the sentinel at the end so the observer can fire again if it
+		// is still visible (e.g. the loaded month was short).
+		this.repositionLoadMoreSentinel();
 	}
 
-	private setupScrollListener(): void {
-		this.removeScrollListener();
-
-		let rafPending = false;
-		this.scrollHandler = () => {
-			if (rafPending || this.isLoadingMore || !this.hasMoreMonths) {
-				return;
-			}
-			rafPending = true;
-			requestAnimationFrame(() => {
-				rafPending = false;
-				const { scrollTop, scrollHeight, clientHeight } = this.timelineContentEl;
-				const scrolledToBottom = scrollTop + clientHeight >= scrollHeight - 100;
-				if (scrolledToBottom) {
-					this.loadOlderMonth();
+	private setupLoadMoreObserver(): void {
+		this.loadMoreObserver = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						this.loadOlderMonth();
+					}
 				}
-			});
-		};
-
-		this.timelineContentEl.addEventListener('scroll', this.scrollHandler, { passive: true });
+			},
+			{ root: this.timelineContentEl, rootMargin: '300px 0px' }
+		);
 	}
 
-	private removeScrollListener(): void {
-		if (this.scrollHandler) {
-			this.timelineContentEl?.removeEventListener('scroll', this.scrollHandler);
-			this.scrollHandler = null;
+	private destroyLoadMoreObserver(): void {
+		if (this.loadMoreObserver) {
+			this.loadMoreObserver.disconnect();
+			this.loadMoreObserver = null;
 		}
+		this.loadMoreSentinel = null;
 	}
 
 	private setupCardObserver(): void {
@@ -468,37 +454,31 @@ export class TimelineView extends ItemView {
 		this.pendingCardRenders.clear();
 	}
 
-	private addLoadMoreButton(): void {
-		const existingBtn = this.timelineContentEl.querySelector('.moments-load-more');
-		if (existingBtn) {
-			existingBtn.remove();
-		}
+	private addLoadMoreSentinel(): void {
+		this.removeLoadMoreSentinel();
 
 		if (!this.hasMoreMonths) {
 			return;
 		}
 
-		const loadMoreBtn = this.timelineContentEl.createEl('button', {
-			cls: 'moments-load-more',
-			text: 'Load more...',
+		this.loadMoreSentinel = this.timelineContentEl.createEl('div', {
+			cls: 'moments-load-sentinel',
 		});
-
-		loadMoreBtn.addEventListener('click', () => {
-			this.loadOlderMonth();
-		});
+		this.loadMoreObserver?.observe(this.loadMoreSentinel);
 	}
 
-	private updateLoadMoreButton(): void {
-		const btn = this.timelineContentEl.querySelector('.moments-load-more');
-		if (btn && !this.hasMoreMonths) {
-			btn.remove();
+	/** Move the sentinel back to the end after older months are appended. */
+	private repositionLoadMoreSentinel(): void {
+		if (this.loadMoreSentinel && this.hasMoreMonths) {
+			this.timelineContentEl.appendChild(this.loadMoreSentinel);
 		}
 	}
 
-	private removeLoadMoreButton(): void {
-		const btn = this.timelineContentEl.querySelector('.moments-load-more');
-		if (btn) {
-			btn.remove();
+	private removeLoadMoreSentinel(): void {
+		if (this.loadMoreSentinel) {
+			this.loadMoreObserver?.unobserve(this.loadMoreSentinel);
+			this.loadMoreSentinel.remove();
+			this.loadMoreSentinel = null;
 		}
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -148,6 +148,10 @@
 	font-weight: 600;
 	font-size: 14px;
 	color: var(--text-normal);
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .moments-card-title p {
@@ -219,11 +223,9 @@
 	text-decoration: underline;
 }
 
-/* Load More Button */
-.moments-load-more {
-	display: block;
-	width: 100%;
-	margin-top: 16px;
+/* Load More Sentinel — observed to auto-load older months */
+.moments-load-sentinel {
+	height: 1px;
 }
 
 /* Empty State */


### PR DESCRIPTION
## Summary

Fixes three tracked issues:

- **#16** — Standalone note creation now evaluates `{{title}}`, `{{date}}`, and `{{time}}` placeholders when applying a template via the core Templates plugin (previously inserted verbatim).
- **#17** — The moment modal's primary **Create** button now sits on the right, with **Cancel** on the left.
- **#18** — Long moment-card titles truncate with an ellipsis; the always-present "Load more" button is replaced with an `IntersectionObserver`-driven sentinel that auto-loads older months until none remain.

## Changes

- `evaluateCoreTemplate()` resolves core Templates placeholders using the plugin's configured date/time formats.
- Moment modal button order swapped (Cancel left, Create right).
- `.moments-card-title` truncates with an ellipsis instead of wrapping to multiple lines.
- Scroll listener + persistent button replaced with an invisible `.moments-load-sentinel`.
- Pagination logic extracted into pure `findMonthWithDates()` / `hasDatesBefore()` helpers, with `loadMonth()` rewritten non-recursively.

## Testing

`npm run lint && npm test && npm run build` — all pass; 261 tests (+19 new covering template evaluation and pagination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)