### PR TITLE
Add target folder for standalone moments (#14)

### DIFF
--- a/__tests__/__mocks__/obsidian.ts
+++ b/__tests__/__mocks__/obsidian.ts
@@ -13,3 +13,31 @@ const resolved = momentImport as unknown as { default?: unknown };
 export const moment = (
 	typeof resolved.default === 'function' ? resolved.default : momentImport
 ) as typeof import('moment');
+
+/**
+ * Minimal `Notice` stand-in — records the message, performs no UI.
+ */
+export class Notice {
+	message: string | DocumentFragment;
+	constructor(message: string | DocumentFragment) {
+		this.message = message;
+	}
+	setMessage(message: string | DocumentFragment): this {
+		this.message = message;
+		return this;
+	}
+	hide(): void {
+		/* no-op in tests */
+	}
+}
+
+/**
+ * Test stand-in for Obsidian's `normalizePath`: collapse duplicate slashes
+ * and strip leading/trailing slashes.
+ */
+export function normalizePath(path: string): string {
+	return path
+		.replace(/[\\/]+/g, '/')
+		.replace(/^\/+|\/+$/g, '')
+		.trim();
+}

--- a/__tests__/core/folder-helpers.test.ts
+++ b/__tests__/core/folder-helpers.test.ts
@@ -1,0 +1,42 @@
+import { filterFolderSuggestions } from '../../src/core/folder-helpers';
+
+const folders = [
+	{ path: '/' },
+	{ path: 'Journal' },
+	{ path: 'Journal/2026' },
+	{ path: 'Work/Notes' },
+	{ path: 'Archive' },
+];
+
+describe('filterFolderSuggestions', () => {
+	it('returns all folders for an empty query', () => {
+		expect(filterFolderSuggestions(folders, '')).toHaveLength(folders.length);
+	});
+
+	it('matches folders by case-insensitive substring', () => {
+		const result = filterFolderSuggestions(folders, 'note');
+		expect(result.map((f) => f.path)).toEqual(['Work/Notes']);
+	});
+
+	it('is case-insensitive on the folder path', () => {
+		const result = filterFolderSuggestions(folders, 'WORK');
+		expect(result.map((f) => f.path)).toEqual(['Work/Notes']);
+	});
+
+	it('orders prefix matches before other substring matches', () => {
+		const result = filterFolderSuggestions(
+			[{ path: 'Work/Journal' }, { path: 'Journal' }],
+			'jour'
+		);
+		expect(result.map((f) => f.path)).toEqual(['Journal', 'Work/Journal']);
+	});
+
+	it('orders shorter paths first among equal-rank matches', () => {
+		const result = filterFolderSuggestions(folders, 'journal');
+		expect(result.map((f) => f.path)).toEqual(['Journal', 'Journal/2026']);
+	});
+
+	it('returns an empty array when nothing matches', () => {
+		expect(filterFolderSuggestions(folders, 'zzz')).toEqual([]);
+	});
+});

--- a/__tests__/helpers/fake-app.ts
+++ b/__tests__/helpers/fake-app.ts
@@ -1,0 +1,60 @@
+import type { App } from 'obsidian';
+
+interface FakeFile {
+	path: string;
+	name: string;
+	basename: string;
+	extension: string;
+}
+
+function makeFile(path: string): FakeFile {
+	const name = path.split('/').pop() ?? path;
+	return {
+		path,
+		name,
+		basename: name.replace(/\.md$/, ''),
+		extension: 'md',
+	};
+}
+
+export interface FakeAppHandle {
+	app: App;
+	createdFiles: { path: string; content: string }[];
+	createdFolders: string[];
+}
+
+/**
+ * Build an in-memory fake `App` whose vault tracks created files and folders.
+ * Only the vault methods used by `createStandaloneNote` are implemented.
+ */
+export function createFakeApp(options?: {
+	existingFiles?: string[];
+	existingFolders?: string[];
+}): FakeAppHandle {
+	const files = new Set(options?.existingFiles ?? []);
+	const folders = new Set(options?.existingFolders ?? []);
+	const createdFiles: { path: string; content: string }[] = [];
+	const createdFolders: string[] = [];
+
+	const vault = {
+		getFileByPath(path: string): FakeFile | null {
+			return files.has(path) ? makeFile(path) : null;
+		},
+		getFolderByPath(path: string): unknown {
+			return folders.has(path) ? { path } : null;
+		},
+		createFolder(path: string): Promise<unknown> {
+			folders.add(path);
+			createdFolders.push(path);
+			return Promise.resolve({ path });
+		},
+		create(path: string, content: string): Promise<FakeFile> {
+			files.add(path);
+			createdFiles.push({ path, content });
+			return Promise.resolve(makeFile(path));
+		},
+	};
+
+	const app = { vault } as unknown as App;
+	return { app, createdFiles, createdFolders };
+}

--- a/__tests__/integration/standalone-note.test.ts
+++ b/__tests__/integration/standalone-note.test.ts
@@ -90,4 +90,35 @@ describe('createStandaloneNote', () => {
 
 		expect(createdFiles.map((f) => f.content)).toEqual(['']);
 	});
+
+	it('normalizes a trailing slash on the folder path', async () => {
+		const { app, createdFiles, createdFolders } = createFakeApp({
+			existingFolders: ['Journal'],
+		});
+
+		await createStandaloneNote(app, settings(), {
+			...result,
+			folder: 'Journal/',
+		});
+
+		// The existing folder is matched — no redundant create.
+		expect(createdFolders).toEqual([]);
+		expect(createdFiles.map((f) => f.path)).toEqual([
+			'Journal/2026-05-21 - Test.md',
+		]);
+	});
+
+	it('treats a whitespace-only folder as the vault root', async () => {
+		const { app, createdFiles, createdFolders } = createFakeApp();
+
+		await createStandaloneNote(app, settings(), {
+			...result,
+			folder: '   ',
+		});
+
+		expect(createdFolders).toEqual([]);
+		expect(createdFiles.map((f) => f.path)).toEqual([
+			'2026-05-21 - Test.md',
+		]);
+	});
 });

--- a/__tests__/integration/standalone-note.test.ts
+++ b/__tests__/integration/standalone-note.test.ts
@@ -1,0 +1,93 @@
+import { createStandaloneNote } from '../../src/commands/standalone-note';
+import { createFakeApp } from '../helpers/fake-app';
+import { DEFAULT_SETTINGS } from '../../src/settings/settings';
+import type { MomentsSettings } from '../../src/settings/settings';
+
+function settings(overrides: Partial<MomentsSettings> = {}): MomentsSettings {
+	return { ...DEFAULT_SETTINGS, ...overrides };
+}
+
+const result = { title: 'Test', date: '2026-05-21', folder: 'Journal' };
+
+describe('createStandaloneNote', () => {
+	it('creates the note inside the given folder', async () => {
+		const { app, createdFiles } = createFakeApp({
+			existingFolders: ['Journal'],
+		});
+
+		const out = await createStandaloneNote(app, settings(), result);
+
+		expect(out.existed).toBe(false);
+		expect(createdFiles.map((f) => f.path)).toEqual([
+			'Journal/2026-05-21 - Test.md',
+		]);
+	});
+
+	it('creates the note at the vault root when folder is empty', async () => {
+		const { app, createdFiles } = createFakeApp();
+
+		await createStandaloneNote(app, settings(), { ...result, folder: '' });
+
+		expect(createdFiles.map((f) => f.path)).toEqual(['2026-05-21 - Test.md']);
+	});
+
+	it('auto-creates the folder when it does not exist', async () => {
+		const { app, createdFolders } = createFakeApp();
+
+		await createStandaloneNote(app, settings(), {
+			...result,
+			folder: 'New/Sub',
+		});
+
+		expect(createdFolders).toContain('New/Sub');
+	});
+
+	it('does not create a folder that already exists', async () => {
+		const { app, createdFolders } = createFakeApp({
+			existingFolders: ['Journal'],
+		});
+
+		await createStandaloneNote(app, settings(), result);
+
+		expect(createdFolders).toEqual([]);
+	});
+
+	it('returns the existing file without creating a duplicate', async () => {
+		const { app, createdFiles } = createFakeApp({
+			existingFiles: ['Journal/2026-05-21 - Test.md'],
+			existingFolders: ['Journal'],
+		});
+
+		const out = await createStandaloneNote(app, settings(), result);
+
+		expect(out.existed).toBe(true);
+		expect(out.file.path).toBe('Journal/2026-05-21 - Test.md');
+		expect(createdFiles).toEqual([]);
+	});
+
+	it('renders note content from the noteTemplate setting', async () => {
+		const { app, createdFiles } = createFakeApp({
+			existingFolders: ['Journal'],
+		});
+
+		await createStandaloneNote(
+			app,
+			settings({ noteTemplate: 'Logged on {{date}}' }),
+			result
+		);
+
+		expect(createdFiles.map((f) => f.content)).toEqual([
+			'Logged on 2026-05-21',
+		]);
+	});
+
+	it('creates an empty note when noteTemplate is blank', async () => {
+		const { app, createdFiles } = createFakeApp({
+			existingFolders: ['Journal'],
+		});
+
+		await createStandaloneNote(app, settings(), result);
+
+		expect(createdFiles.map((f) => f.content)).toEqual(['']);
+	});
+});

--- a/src/commands/create-standalone.ts
+++ b/src/commands/create-standalone.ts
@@ -60,7 +60,7 @@ export function createStandaloneMoment(
 					{
 						title: result.title,
 						date: result.date,
-						folder: result.folder ?? defaultFolder,
+						folder: result.folder || defaultFolder,
 					}
 				);
 

--- a/src/commands/create-standalone.ts
+++ b/src/commands/create-standalone.ts
@@ -1,8 +1,7 @@
-import { App, Notice, normalizePath } from 'obsidian';
+import { App, Notice } from 'obsidian';
 import type { MomentsSettings } from '../settings/settings';
 import { MomentModal } from '../ui/moment-modal';
-import { buildFilename, renderTemplate } from '../core/template-engine';
-import type { TemplateVariables } from '../core/template-engine';
+import { createStandaloneNote } from './standalone-note';
 import {
 	hasTemplatesAvailable,
 	TemplateSuggesterModal,
@@ -17,8 +16,12 @@ function getNewNoteFolderPath(app: App): string {
 	const vault = app.vault as App['vault'] & {
 		getConfig(key: string): unknown;
 	};
-	const newFileLocation = vault.getConfig('newFileLocation') as string | undefined;
-	const newFileFolderPath = vault.getConfig('newFileFolderPath') as string | undefined;
+	const newFileLocation = vault.getConfig('newFileLocation') as
+		| string
+		| undefined;
+	const newFileFolderPath = vault.getConfig('newFileFolderPath') as
+		| string
+		| undefined;
 
 	if (newFileLocation === 'folder' && newFileFolderPath) {
 		return newFileFolderPath;
@@ -42,46 +45,28 @@ export function createStandaloneMoment(
 	app: App,
 	settings: MomentsSettings
 ): void {
-	// Open the moment modal
 	new MomentModal(app, {
 		title: 'Create new moment note',
 		dateFormat: settings.dateFormat,
 		onSubmit: async (result) => {
 			try {
-				// Build template variables
-				const templateVars: TemplateVariables = {
-					date: result.date,
-					title: result.title || null,
-				};
+				const { file, existed } = await createStandaloneNote(
+					app,
+					settings,
+					{
+						title: result.title,
+						date: result.date,
+						folder: getNewNoteFolderPath(app),
+					}
+				);
 
-				// Build filename
-				const filename = buildFilename(templateVars, settings.filenameTemplate);
+				await app.workspace.getLeaf().openFile(file);
 
-				// Get folder path
-				const folderPath = getNewNoteFolderPath(app);
-				const fullPath = normalizePath(folderPath ? `${folderPath}/${filename}` : filename);
-
-				// Check if file already exists
-				const existingFile = app.vault.getFileByPath(fullPath);
-				if (existingFile) {
-					new Notice(`File already exists: ${filename}`);
-					await app.workspace.getLeaf().openFile(existingFile);
+				if (existed) {
+					new Notice(`File already exists: ${file.name}`);
 					return;
 				}
 
-				// Build initial content from plugin settings (if no template will be applied)
-				let content = '';
-				if (settings.noteTemplate) {
-					content = renderTemplate(settings.noteTemplate, templateVars);
-				}
-
-				// Create the file
-				const file = await app.vault.create(fullPath, content);
-
-				// Open the new file
-				await app.workspace.getLeaf().openFile(file);
-
-				// If templates are available, offer to apply one
 				if (hasTemplatesAvailable(app)) {
 					new TemplateSuggesterModal(app, (templateFile) => {
 						if (templateFile) {
@@ -90,7 +75,10 @@ export function createStandaloneMoment(
 									new Notice('Moment note created with template');
 								})
 								.catch((error: unknown) => {
-									console.error('Moments: Failed to apply template:', error);
+									console.error(
+										'Moments: Failed to apply template:',
+										error
+									);
 									new Notice('Failed to apply template');
 								});
 						} else {

--- a/src/commands/create-standalone.ts
+++ b/src/commands/create-standalone.ts
@@ -45,9 +45,13 @@ export function createStandaloneMoment(
 	app: App,
 	settings: MomentsSettings
 ): void {
+	const defaultFolder =
+		settings.standaloneFolder || getNewNoteFolderPath(app);
+
 	new MomentModal(app, {
 		title: 'Create new moment note',
 		dateFormat: settings.dateFormat,
+		folderField: { defaultValue: defaultFolder },
 		onSubmit: async (result) => {
 			try {
 				const { file, existed } = await createStandaloneNote(
@@ -56,7 +60,7 @@ export function createStandaloneMoment(
 					{
 						title: result.title,
 						date: result.date,
-						folder: getNewNoteFolderPath(app),
+						folder: result.folder ?? defaultFolder,
 					}
 				);
 

--- a/src/commands/standalone-note.ts
+++ b/src/commands/standalone-note.ts
@@ -1,0 +1,59 @@
+import { App, TFile, normalizePath } from 'obsidian';
+import type { MomentsSettings } from '../settings/settings';
+import { buildFilename, renderTemplate } from '../core/template-engine';
+import type { TemplateVariables } from '../core/template-engine';
+
+/**
+ * Inputs for creating a standalone moment note.
+ */
+export interface StandaloneNoteResult {
+	title: string;
+	date: string;
+	/** Target folder path ('' = vault root). */
+	folder: string;
+}
+
+/**
+ * Create a standalone moment note in the requested folder.
+ *
+ * Returns the created file, or an existing file (with `existed: true`) when a
+ * note already lives at the target path. Auto-creates the target folder when
+ * it is missing. Contains no UI — callers handle notices and opening the file.
+ */
+export async function createStandaloneNote(
+	app: App,
+	settings: MomentsSettings,
+	result: StandaloneNoteResult
+): Promise<{ file: TFile; existed: boolean }> {
+	const templateVars: TemplateVariables = {
+		date: result.date,
+		title: result.title || null,
+	};
+
+	const filename = buildFilename(templateVars, settings.filenameTemplate);
+	const folder = result.folder.trim();
+	const fullPath = normalizePath(folder ? `${folder}/${filename}` : filename);
+
+	const existing = app.vault.getFileByPath(fullPath);
+	if (existing) {
+		return { file: existing, existed: true };
+	}
+
+	if (folder && !app.vault.getFolderByPath(folder)) {
+		try {
+			await app.vault.createFolder(folder);
+		} catch (error) {
+			// Tolerate a concurrent creation race; rethrow anything else.
+			if (!String(error).includes('already exists')) {
+				throw error;
+			}
+		}
+	}
+
+	const content = settings.noteTemplate
+		? renderTemplate(settings.noteTemplate, templateVars)
+		: '';
+
+	const file = await app.vault.create(fullPath, content);
+	return { file, existed: false };
+}

--- a/src/commands/standalone-note.ts
+++ b/src/commands/standalone-note.ts
@@ -31,7 +31,10 @@ export async function createStandaloneNote(
 	};
 
 	const filename = buildFilename(templateVars, settings.filenameTemplate);
-	const folder = result.folder.trim();
+	const trimmedFolder = result.folder.trim();
+	// Normalize so folder lookups match Obsidian's internal index (e.g. a
+	// trailing slash on 'Journal/' would otherwise miss the existing folder).
+	const folder = trimmedFolder ? normalizePath(trimmedFolder) : '';
 	const fullPath = normalizePath(folder ? `${folder}/${filename}` : filename);
 
 	const existing = app.vault.getFileByPath(fullPath);

--- a/src/core/folder-helpers.ts
+++ b/src/core/folder-helpers.ts
@@ -1,0 +1,33 @@
+/**
+ * Filter and rank folder-like items for autocomplete suggestions.
+ *
+ * Pure function — no Obsidian imports — so it operates on any object with a
+ * `path` string and returns the same items, ranked:
+ *   1. prefix matches before mid-string matches
+ *   2. shorter paths first
+ *   3. alphabetical
+ */
+export function filterFolderSuggestions<T extends { path: string }>(
+	folders: T[],
+	query: string
+): T[] {
+	const q = query.trim().toLowerCase();
+
+	const matches = q
+		? folders.filter((f) => f.path.toLowerCase().includes(q))
+		: folders.slice();
+
+	return matches.sort((a, b) => {
+		const ap = a.path.toLowerCase();
+		const bp = b.path.toLowerCase();
+
+		if (q) {
+			const aStarts = ap.startsWith(q);
+			const bStarts = bp.startsWith(q);
+			if (aStarts !== bStarts) return aStarts ? -1 : 1;
+		}
+
+		if (ap.length !== bp.length) return ap.length - bp.length;
+		return ap.localeCompare(bp);
+	});
+}

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -1,5 +1,6 @@
 import { App, PluginSettingTab, SettingGroup } from 'obsidian';
 import type MomentsPlugin from '../main';
+import { FolderSuggest } from '../ui/folder-suggest';
 
 /**
  * Settings tab for the Moments plugin
@@ -136,6 +137,23 @@ export class MomentsSettingTab extends PluginSettingTab {
 		// Standalone moment settings section
 		new SettingGroup(containerEl)
 			.setHeading('Standalone notes')
+			.addSetting((setting) => {
+				setting
+					.setName('Default folder')
+					.setDesc(
+						"Folder for new standalone moment notes. Leave blank to use Obsidian's new-note location."
+					)
+					.addText((text) => {
+						text
+							.setPlaceholder('Journal')
+							.setValue(this.plugin.settings.standaloneFolder)
+							.onChange(async (value) => {
+								this.plugin.settings.standaloneFolder = value.trim();
+								await this.plugin.saveSettings();
+							});
+						new FolderSuggest(this.app, text.inputEl);
+					});
+			})
 			.addSetting((setting) => {
 				setting
 					.setName('Filename template')

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, SettingGroup } from 'obsidian';
+import { App, PluginSettingTab, SettingGroup, normalizePath } from 'obsidian';
 import type MomentsPlugin from '../main';
 import { FolderSuggest } from '../ui/folder-suggest';
 
@@ -148,7 +148,10 @@ export class MomentsSettingTab extends PluginSettingTab {
 							.setPlaceholder('Journal')
 							.setValue(this.plugin.settings.standaloneFolder)
 							.onChange(async (value) => {
-								this.plugin.settings.standaloneFolder = value.trim();
+								const trimmed = value.trim();
+								this.plugin.settings.standaloneFolder = trimmed
+									? normalizePath(trimmed)
+									: '';
 								await this.plugin.saveSettings();
 							});
 						new FolderSuggest(this.app, text.inputEl);

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -40,6 +40,8 @@ export interface MomentsSettings {
 	filenameTemplate: string;
 	/** Template for note content */
 	noteTemplate: string;
+	/** Default folder for new standalone moment notes ('' = use Obsidian's location) */
+	standaloneFolder: string;
 
 	// Timeline settings
 	/** Auto-follow timeline when viewing periodic notes */
@@ -78,6 +80,7 @@ export const DEFAULT_SETTINGS: MomentsSettings = {
 	// Standalone moment settings
 	filenameTemplate: DEFAULT_FILENAME_TEMPLATE,
 	noteTemplate: '',
+	standaloneFolder: '',
 
 	// Timeline settings
 	autoFilterOnPeriodicNote: true,

--- a/src/ui/folder-suggest.ts
+++ b/src/ui/folder-suggest.ts
@@ -26,7 +26,6 @@ export class FolderSuggest extends AbstractInputSuggest<TFolder> {
 	selectSuggestion(folder: TFolder): void {
 		const value = folder.isRoot() ? '' : folder.path;
 		this.setValue(value);
-		this.inputEl.value = value;
 		this.inputEl.dispatchEvent(new Event('input'));
 		this.close();
 	}

--- a/src/ui/folder-suggest.ts
+++ b/src/ui/folder-suggest.ts
@@ -1,0 +1,33 @@
+import { AbstractInputSuggest, App, TFolder } from 'obsidian';
+import { filterFolderSuggestions } from '../core/folder-helpers';
+
+/**
+ * Provides vault folder autocomplete for a text input.
+ */
+export class FolderSuggest extends AbstractInputSuggest<TFolder> {
+	private inputEl: HTMLInputElement;
+
+	constructor(app: App, inputEl: HTMLInputElement) {
+		super(app, inputEl);
+		this.inputEl = inputEl;
+	}
+
+	getSuggestions(query: string): TFolder[] {
+		const folders = this.app.vault
+			.getAllLoadedFiles()
+			.filter((file): file is TFolder => file instanceof TFolder);
+		return filterFolderSuggestions(folders, query);
+	}
+
+	renderSuggestion(folder: TFolder, el: HTMLElement): void {
+		el.setText(folder.isRoot() ? '/ (vault root)' : folder.path);
+	}
+
+	selectSuggestion(folder: TFolder): void {
+		const value = folder.isRoot() ? '' : folder.path;
+		this.setValue(value);
+		this.inputEl.value = value;
+		this.inputEl.dispatchEvent(new Event('input'));
+		this.close();
+	}
+}

--- a/src/ui/moment-modal.ts
+++ b/src/ui/moment-modal.ts
@@ -1,6 +1,7 @@
 import { App, Modal, Setting, Notice } from 'obsidian';
 import { formatDate, parseDate, DEFAULT_DATE_FORMAT } from '../core/date-parser';
 import { NoteLinkSuggest } from './note-link-suggest';
+import { FolderSuggest } from './folder-suggest';
 import { MODAL_FOCUS_DELAY_MS } from '../constants';
 
 /**
@@ -9,6 +10,8 @@ import { MODAL_FOCUS_DELAY_MS } from '../constants';
 export interface MomentModalResult {
 	title: string;
 	date: string;
+	/** Target folder — only present when the modal showed a folder field. */
+	folder?: string;
 }
 
 /**
@@ -21,12 +24,15 @@ export class MomentModal extends Modal {
 	private titleText: string = '';
 	private dateText: string;
 	private modalTitle: string;
+	private folderField: { defaultValue: string } | null = null;
+	private folderText: string = '';
 
 	constructor(
 		app: App,
 		options: {
 			title: string;
 			dateFormat: string;
+			folderField?: { defaultValue: string };
 			onSubmit: (result: MomentModalResult) => void | Promise<void>;
 		}
 	) {
@@ -35,6 +41,8 @@ export class MomentModal extends Modal {
 		this.dateFormat = options.dateFormat;
 		this.onSubmit = options.onSubmit;
 		this.dateText = formatDate(new Date(), this.dateFormat);
+		this.folderField = options.folderField ?? null;
+		this.folderText = options.folderField?.defaultValue ?? '';
 	}
 
 	onOpen() {
@@ -74,6 +82,22 @@ export class MomentModal extends Modal {
 				});
 			});
 
+		// Folder input — only when the caller requested it (standalone notes)
+		if (this.folderField) {
+			new Setting(contentEl)
+				.setName('Folder')
+				.setDesc('Where to create the note')
+				.addText((text) => {
+					text
+						.setPlaceholder('Journal')
+						.setValue(this.folderText)
+						.onChange((value) => {
+							this.folderText = value;
+						});
+					new FolderSuggest(this.app, text.inputEl);
+				});
+		}
+
 		// Buttons — Cancel on the left, primary Create action on the right
 		new Setting(contentEl)
 			.addButton((btn) =>
@@ -107,6 +131,7 @@ export class MomentModal extends Modal {
 		this.result = {
 			title: this.titleText.trim(),
 			date: this.dateText,
+			folder: this.folderField ? this.folderText.trim() : undefined,
 		};
 
 		this.close();


### PR DESCRIPTION
## Summary

Closes #14 — lets users choose which folder a standalone moment note is created in.

- New **Default folder** setting (under **Settings → Moments → Standalone notes**) with folder autocomplete. Blank falls back to Obsidian's new-note location, so existing behavior is unchanged for users who don't configure it.
- The **Create new moment note** modal gains a **Folder** field, pre-filled with the default and editable per-creation, also with folder autocomplete.
- A missing target folder is created automatically (including parent folders).
- Note-creation logic is extracted into a testable `createStandaloneNote` function; the modal command keeps only UI wiring.

## Implementation notes

- `filterFolderSuggestions` — pure, unit-tested ranking helper in `src/core/`.
- `FolderSuggest` — `AbstractInputSuggest` component shared by the settings input and the modal field.
- New test infrastructure: `Notice`/`normalizePath` added to the Obsidian mock, plus an in-memory `createFakeApp` helper for integration tests.
- Inline moments are unaffected (`folderField` is optional and not passed by the inline command).

Design spec and implementation plan are included under `docs/superpowers/`.

## Test Plan

- [x] `npm run lint && npm test && npm run build` — clean, 255 tests pass
- [ ] In a vault: **Default folder** setting appears with autocomplete
- [ ] **Create new standalone moment** shows a pre-filled, editable **Folder** field
- [ ] Creating with a new folder name auto-creates that folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)